### PR TITLE
Refactor: Rename Base Class and Update UnityAdapter

### DIFF
--- a/Runtime/Adapters/DebugLogAdapter.cs
+++ b/Runtime/Adapters/DebugLogAdapter.cs
@@ -1,6 +1,6 @@
 using System;
 using UnityEngine;
-using ILogger = Lunar.Interfaces.ILogger;
+using ILogger = Lunar.Core.Base.Interfaces.ILogger;
 using Object = UnityEngine.Object;
 
 namespace Lunar.Adapters.Unity

--- a/Runtime/Adapters/InputAdapter.cs
+++ b/Runtime/Adapters/InputAdapter.cs
@@ -1,25 +1,26 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using Lunar.Interfaces;
+using Lunar.Core.Base.Interfaces;
 using UnityEngine;
 using System.Linq;
+using Lunar.Core.Base;
 
 namespace Lunar.Adapters.Unity
 {
     public class InputAdapter : IInput
     {
-        public bool GetKeyDown(KeyCode keycode)
+        public bool GetKeyDown(KeyCodeBase keycode)
         {
             return Input.GetKeyDown(keycode.ToUnity());
         }
 
-        public bool GetKey(KeyCode keycode)
+        public bool GetKey(KeyCodeBase keycode)
         {
             return Input.GetKey(keycode.ToUnity());
         }
 
-        public bool GetKeyUp(KeyCode keycode)
+        public bool GetKeyUp(KeyCodeBase keycode)
         {
             return Input.GetKeyUp(keycode.ToUnity());
         }
@@ -27,16 +28,16 @@ namespace Lunar.Adapters.Unity
 
     public static class KeyCodeConverter
     {
-        private static readonly ConcurrentDictionary<KeyCode, UnityEngine.KeyCode> Cache = new();
+        private static readonly ConcurrentDictionary<KeyCodeBase, UnityEngine.KeyCode> Cache = new();
 
         // If some key names are inconsistent on both sides, they can be overwritten here uniformly
-        private static readonly Dictionary<KeyCode, UnityEngine.KeyCode> Overrides
+        private static readonly Dictionary<KeyCodeBase, UnityEngine.KeyCode> Overrides
             = new()
             {
                 // [KeyCode.SomeLunarName] = UnityEngine.KeyCode.SomeDifferentUnityName,
             };
 
-        public static UnityEngine.KeyCode ToUnity(this KeyCode key)
+        public static UnityEngine.KeyCode ToUnity(this KeyCodeBase key)
         {
             if (Overrides.TryGetValue(key, out var overridden))
             {
@@ -60,16 +61,16 @@ namespace Lunar.Adapters.Unity
     }
     public class InputActionsAdapter : IInputActions
     {
-        public Dictionary<string, KeyCode[]> Bindings { get; }
+        public Dictionary<string, KeyCodeBase[]> Bindings { get; }
         public IInput Input { get; }
 
-        public InputActionsAdapter(IInput input, Dictionary<string, KeyCode[]> bindings)
+        public InputActionsAdapter(IInput input, Dictionary<string, KeyCodeBase[]> bindings)
         {
             Input = input;
             Bindings = bindings;
         }
 
-        public bool SetBinding(string action, params KeyCode[] keys)
+        public bool SetBinding(string action, params KeyCodeBase[] keys)
         {
             if (string.IsNullOrWhiteSpace(action))
             {
@@ -81,7 +82,7 @@ namespace Lunar.Adapters.Unity
                 return false;
             }
 
-            if (keys.Any(key => !Enum.IsDefined(typeof(KeyCode), key)))
+            if (keys.Any(key => !Enum.IsDefined(typeof(KeyCodeBase), key)))
             {
                 return false;
             }

--- a/Runtime/Adapters/InputAdapter.cs
+++ b/Runtime/Adapters/InputAdapter.cs
@@ -10,17 +10,17 @@ namespace Lunar.Adapters.Unity
 {
     public class InputAdapter : IInput
     {
-        public bool GetKeyDown(KeyCodeBase keycode)
+        public bool GetKeyDown(KeyCodeHandle keycode)
         {
             return Input.GetKeyDown(keycode.ToUnity());
         }
 
-        public bool GetKey(KeyCodeBase keycode)
+        public bool GetKey(KeyCodeHandle keycode)
         {
             return Input.GetKey(keycode.ToUnity());
         }
 
-        public bool GetKeyUp(KeyCodeBase keycode)
+        public bool GetKeyUp(KeyCodeHandle keycode)
         {
             return Input.GetKeyUp(keycode.ToUnity());
         }
@@ -28,16 +28,16 @@ namespace Lunar.Adapters.Unity
 
     public static class KeyCodeConverter
     {
-        private static readonly ConcurrentDictionary<KeyCodeBase, UnityEngine.KeyCode> Cache = new();
+        private static readonly ConcurrentDictionary<KeyCodeHandle, UnityEngine.KeyCode> Cache = new();
 
         // If some key names are inconsistent on both sides, they can be overwritten here uniformly
-        private static readonly Dictionary<KeyCodeBase, UnityEngine.KeyCode> Overrides
+        private static readonly Dictionary<KeyCodeHandle, UnityEngine.KeyCode> Overrides
             = new()
             {
                 // [KeyCode.SomeLunarName] = UnityEngine.KeyCode.SomeDifferentUnityName,
             };
 
-        public static UnityEngine.KeyCode ToUnity(this KeyCodeBase key)
+        public static UnityEngine.KeyCode ToUnity(this KeyCodeHandle key)
         {
             if (Overrides.TryGetValue(key, out var overridden))
             {
@@ -61,16 +61,16 @@ namespace Lunar.Adapters.Unity
     }
     public class InputActionsAdapter : IInputActions
     {
-        public Dictionary<string, KeyCodeBase[]> Bindings { get; }
+        public Dictionary<string, KeyCodeHandle[]> Bindings { get; }
         public IInput Input { get; }
 
-        public InputActionsAdapter(IInput input, Dictionary<string, KeyCodeBase[]> bindings)
+        public InputActionsAdapter(IInput input, Dictionary<string, KeyCodeHandle[]> bindings)
         {
             Input = input;
             Bindings = bindings;
         }
 
-        public bool SetBinding(string action, params KeyCodeBase[] keys)
+        public bool SetBinding(string action, params KeyCodeHandle[] keys)
         {
             if (string.IsNullOrWhiteSpace(action))
             {
@@ -82,7 +82,7 @@ namespace Lunar.Adapters.Unity
                 return false;
             }
 
-            if (keys.Any(key => !Enum.IsDefined(typeof(KeyCodeBase), key)))
+            if (keys.Any(key => !Enum.IsDefined(typeof(KeyCodeHandle), key)))
             {
                 return false;
             }

--- a/Runtime/Adapters/ResourcesAdapter.cs
+++ b/Runtime/Adapters/ResourcesAdapter.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Lunar.Interfaces;
+using Lunar.Core.Base.Interfaces;
 using UnityEngine;
 using Object = UnityEngine.Object;
 

--- a/Runtime/GameController.cs
+++ b/Runtime/GameController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Lunar.Core.Base;
 using UnityEngine;
 using UnityEngine.Pool;
 
@@ -66,12 +67,12 @@ namespace Lunar.Adapters.Unity
                 ResourcesAsync = new ResourcesAdapter(),
                 InputActions = new InputActionsAdapter(
                     new InputAdapter(),
-                    new Dictionary<string, KeyCode[]>
+                    new Dictionary<string, KeyCodeBase[]>
                     {
-                        ["Play"] = new[] { KeyCode.Space },
-                        ["Pause"] = new[] { KeyCode.P },
-                        ["Resume"] = new[] { KeyCode.R },
-                        ["Cancel"] = new[] { KeyCode.C }
+                        ["Play"] = new[] { KeyCodeBase.Space },
+                        ["Pause"] = new[] { KeyCodeBase.P },
+                        ["Resume"] = new[] { KeyCodeBase.R },
+                        ["Cancel"] = new[] { KeyCodeBase.C }
                     }),
                 Logger = new DebugLogAdapter()
             };

--- a/Runtime/GameController.cs
+++ b/Runtime/GameController.cs
@@ -67,12 +67,12 @@ namespace Lunar.Adapters.Unity
                 ResourcesAsync = new ResourcesAdapter(),
                 InputActions = new InputActionsAdapter(
                     new InputAdapter(),
-                    new Dictionary<string, KeyCodeBase[]>
+                    new Dictionary<string, KeyCodeHandle[]>
                     {
-                        ["Play"] = new[] { KeyCodeBase.Space },
-                        ["Pause"] = new[] { KeyCodeBase.P },
-                        ["Resume"] = new[] { KeyCodeBase.R },
-                        ["Cancel"] = new[] { KeyCodeBase.C }
+                        ["Play"] = new[] { KeyCodeHandle.Space },
+                        ["Pause"] = new[] { KeyCodeHandle.P },
+                        ["Resume"] = new[] { KeyCodeHandle.R },
+                        ["Cancel"] = new[] { KeyCodeHandle.C }
                     }),
                 Logger = new DebugLogAdapter()
             };

--- a/Runtime/GameControllerImplementation.cs
+++ b/Runtime/GameControllerImplementation.cs
@@ -3,7 +3,9 @@ using Arch.Core.Extensions;
 using Arch.System;
 using Lunar.Adapters.Unity.Systems;
 using Lunar.Adapters.Unity.Utils;
-using Lunar.Components;
+using Lunar.Core.Base;
+using Lunar.Core.ECS;
+using Lunar.Core.ECS.Components;
 using UnityEngine;
 using UnityEngine.Pool;
 
@@ -45,14 +47,14 @@ namespace Lunar.Adapters.Unity
                     entity.Add(new TransformComponent());
                 }
 
-                if (gameObjectComponent.GameObject != null)
+                if (gameObjectComponent.GameObjectBase != null)
                 {
                     return;
                 }
 
                 var unityGameObject = _gameObjectPool.Get();
                 unityGameObject.transform.SetParent(_parent);
-                entity.Set(new GameObjectComponent(new GameObject(unityGameObject)));
+                entity.Set(new GameObjectComponent(new GameObjectBase(unityGameObject)));
             });
 
 
@@ -72,19 +74,19 @@ namespace Lunar.Adapters.Unity
                 if (unityGameObject.TryGetComponent<SpriteRenderer>(out var spriteRenderer))
                 {
                     spriteRenderer.enabled = true;
-                    spriteComponent.Sprite = new Sprite(spriteRenderer);
+                    spriteComponent.Sprite = new SpriteBase(spriteRenderer);
                 }
                 else
                 {
-                    spriteComponent.Sprite = new Sprite(unityGameObject.AddComponent<SpriteRenderer>());
+                    spriteComponent.Sprite = new SpriteBase(unityGameObject.AddComponent<SpriteRenderer>());
                 }
             });
 
             world.SubscribeComponentRemoved((in Entity entity, ref GameObjectComponent gameObjectComponent) =>
             {
-                if (gameObjectComponent.GameObject != null)
+                if (gameObjectComponent.GameObjectBase != null)
                 {
-                    _gameObjectPool.Release(gameObjectComponent.GameObject.BaseGameObject as UnityEngine.GameObject);
+                    _gameObjectPool.Release(gameObjectComponent.GameObjectBase.BaseGameObject as UnityEngine.GameObject);
                 }
             });
         }

--- a/Runtime/GameControllerImplementation.cs
+++ b/Runtime/GameControllerImplementation.cs
@@ -47,14 +47,14 @@ namespace Lunar.Adapters.Unity
                     entity.Add(new TransformComponent());
                 }
 
-                if (gameObjectComponent.GameObjectBase != null)
+                if (gameObjectComponent.GameObjectHandle != null)
                 {
                     return;
                 }
 
                 var unityGameObject = _gameObjectPool.Get();
                 unityGameObject.transform.SetParent(_parent);
-                entity.Set(new GameObjectComponent(new GameObjectBase(unityGameObject)));
+                entity.Set(new GameObjectComponent(new GameObjectHandle(unityGameObject)));
             });
 
 
@@ -74,19 +74,19 @@ namespace Lunar.Adapters.Unity
                 if (unityGameObject.TryGetComponent<SpriteRenderer>(out var spriteRenderer))
                 {
                     spriteRenderer.enabled = true;
-                    spriteComponent.Sprite = new SpriteBase(spriteRenderer);
+                    spriteComponent.Sprite = new SpriteHandle(spriteRenderer);
                 }
                 else
                 {
-                    spriteComponent.Sprite = new SpriteBase(unityGameObject.AddComponent<SpriteRenderer>());
+                    spriteComponent.Sprite = new SpriteHandle(unityGameObject.AddComponent<SpriteRenderer>());
                 }
             });
 
             world.SubscribeComponentRemoved((in Entity entity, ref GameObjectComponent gameObjectComponent) =>
             {
-                if (gameObjectComponent.GameObjectBase != null)
+                if (gameObjectComponent.GameObjectHandle != null)
                 {
-                    _gameObjectPool.Release(gameObjectComponent.GameObjectBase.BaseGameObject as UnityEngine.GameObject);
+                    _gameObjectPool.Release(gameObjectComponent.GameObjectHandle.NativeGameObject as UnityEngine.GameObject);
                 }
             });
         }

--- a/Runtime/ServiceRegistry.cs
+++ b/Runtime/ServiceRegistry.cs
@@ -1,4 +1,4 @@
-using Lunar.Interfaces;
+using Lunar.Core.Base.Interfaces;
 
 namespace Lunar.Adapters.Unity
 {

--- a/Runtime/Systems/DebugCreateObjectSystem.cs
+++ b/Runtime/Systems/DebugCreateObjectSystem.cs
@@ -1,7 +1,8 @@
 using Arch.Core;
 using Arch.Core.Extensions;
 using Arch.System;
-using Lunar.Components;
+
+using Lunar.Core.ECS.Components;
 using UnityEngine;
 
 namespace Lunar.Adapters.Unity.Systems

--- a/Runtime/Systems/GameObjectSyncSystem.cs
+++ b/Runtime/Systems/GameObjectSyncSystem.cs
@@ -1,8 +1,8 @@
 using System;
 using Arch.Core;
 using Lunar.Adapters.Unity.Utils;
-using Lunar.Components;
-using Lunar.Systems;
+using Lunar.Core.ECS.Components;
+using Lunar.Core.ECS.Systems;
 using UnityEngine;
 
 namespace Lunar.Adapters.Unity.Systems

--- a/Runtime/Systems/SpriteCleanSystem.cs
+++ b/Runtime/Systems/SpriteCleanSystem.cs
@@ -1,7 +1,9 @@
 using Arch.Core;
 using Lunar.Adapters.Unity.Utils;
-using Lunar.Components;
-using Lunar.Systems;
+
+using Lunar.Core.ECS.Components;
+using Lunar.Core.ECS.Systems;
+
 using UnityEngine;
 
 namespace Lunar.Adapters.Unity.Systems

--- a/Runtime/Systems/SpriteSyncSystem.cs
+++ b/Runtime/Systems/SpriteSyncSystem.cs
@@ -3,9 +3,11 @@ using System;
 using System.Threading.Tasks;
 using Arch.Core;
 using Lunar.Adapters.Unity.Utils;
-using Lunar.Components;
-using Lunar.Interfaces;
-using Lunar.Systems;
+
+using Lunar.Core.Base.Interfaces;
+using Lunar.Core.ECS.Components;
+using Lunar.Core.ECS.Systems;
+
 
 namespace Lunar.Adapters.Unity.Systems
 {

--- a/Runtime/Utils/UnityConversionUtils.cs
+++ b/Runtime/Utils/UnityConversionUtils.cs
@@ -7,7 +7,7 @@ namespace Lunar.Adapters.Unity.Utils
         public static bool TryParseToUnity(this GameObjectComponent gameObject,
             out UnityEngine.GameObject unityGameObject)
         {
-            unityGameObject = gameObject.GameObjectBase.BaseGameObject as UnityEngine.GameObject;
+            unityGameObject = gameObject.GameObjectHandle.NativeGameObject as UnityEngine.GameObject;
 
             return unityGameObject;
 
@@ -19,7 +19,7 @@ namespace Lunar.Adapters.Unity.Utils
         {
             if (sprite.Sprite != null)
             {
-                unitySpriteRenderer = sprite.Sprite.BaseSprite as UnityEngine.SpriteRenderer;
+                unitySpriteRenderer = sprite.Sprite.NativeSprite as UnityEngine.SpriteRenderer;
 
                 return unitySpriteRenderer;
             }

--- a/Runtime/Utils/UnityConversionUtils.cs
+++ b/Runtime/Utils/UnityConversionUtils.cs
@@ -1,4 +1,4 @@
-using Lunar.Components;
+using Lunar.Core.ECS.Components;
 
 namespace Lunar.Adapters.Unity.Utils
 {
@@ -7,7 +7,7 @@ namespace Lunar.Adapters.Unity.Utils
         public static bool TryParseToUnity(this GameObjectComponent gameObject,
             out UnityEngine.GameObject unityGameObject)
         {
-            unityGameObject = gameObject.GameObject.BaseGameObject as UnityEngine.GameObject;
+            unityGameObject = gameObject.GameObjectBase.BaseGameObject as UnityEngine.GameObject;
 
             return unityGameObject;
 

--- a/Runtime/com.bliaik.lunar.runtime.asmdef
+++ b/Runtime/com.bliaik.lunar.runtime.asmdef
@@ -7,7 +7,9 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "Lunar.dll",
+        
+        "Lunar.Core.Base.dll",
+        "Lunar.Core.ECS.dll",
         "Arch.dll",
         "Arch.System.dll"
     ],

--- a/Tests/KeyCodeConverterTests.cs
+++ b/Tests/KeyCodeConverterTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Lunar.Core.Base;
 using NUnit.Framework;
 
 namespace Lunar.Adapters.Unity.Tests
@@ -12,7 +13,7 @@ namespace Lunar.Adapters.Unity.Tests
         {
             var failed = new List<string>();
 
-            foreach (KeyCode lunarKey in Enum.GetValues(typeof(KeyCode)))
+            foreach (KeyCodeBase lunarKey in Enum.GetValues(typeof(KeyCodeBase)))
             {
                 try
                 {

--- a/Tests/KeyCodeConverterTests.cs
+++ b/Tests/KeyCodeConverterTests.cs
@@ -13,7 +13,7 @@ namespace Lunar.Adapters.Unity.Tests
         {
             var failed = new List<string>();
 
-            foreach (KeyCodeBase lunarKey in Enum.GetValues(typeof(KeyCodeBase)))
+            foreach (KeyCodeHandle lunarKey in Enum.GetValues(typeof(KeyCodeHandle)))
             {
                 try
                 {

--- a/Tests/com.bliaik.lunar.tests.asmdef
+++ b/Tests/com.bliaik.lunar.tests.asmdef
@@ -11,7 +11,9 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "Lunar.dll",
+        
+        "Lunar.Core.Base.dll",
+        "Lunar.Core.ECS.dll",
         "nunit.framework.dll"
     ],
     "autoReferenced": true,


### PR DESCRIPTION
### 🚀 What's New?

* Renamed the base class to `Handle` and updated its property names.
* Updated `UnityAdapter` namespace and types to use `Lunar.Core.Base` and `Lunar.Core.ECS`.

---

### 🔗 Related Issues

N/A

---

### 📝 Additional Information

N/A
